### PR TITLE
Add support for downloading files with `xoxc` tokens

### DIFF
--- a/slack-buffer.el
+++ b/slack-buffer.el
@@ -333,7 +333,8 @@
                     (path (slack-image-path url)))
         (let* ((no-token-p (get-text-property (1- (point)) 'no-token))
                (team (slack-buffer-team slack-current-buffer))
-               (token (and (not no-token-p) (oref team token))))
+               (token (and (not no-token-p) (oref team token)))
+               (cookie (and (not no-token-p) (oref team cookie))))
           (cl-labels
               ((on-success ()
                            (slack-buffer-replace-image cur-buffer ts)))
@@ -341,7 +342,8 @@
               (slack-url-copy-file url
                                    path
                                    :success #'on-success
-                                   :token token)))))))
+                                   :token token
+                                   :cookie cookie)))))))
 
 (cl-defmethod slack-buffer-replace ((this slack-buffer) message)
   (let ((team (slack-buffer-team this)))

--- a/slack-file.el
+++ b/slack-file.el
@@ -558,6 +558,7 @@
                                                  filename dir))))
       (slack-url-copy-file url (format "%s%s" dir filename)
                            :token (slack-team-token team)
+                           :cookie (slack-team-cookie team)
                            :sync t)))
 
 (cl-defmethod slack-file-downloadable-p ((file slack-file))

--- a/slack.el
+++ b/slack.el
@@ -198,7 +198,7 @@ Available options (property name, type, default value)
   (interactive
    (let* ((name (read-from-minibuffer "Team Name: "))
           (token (read-from-minibuffer "Token: "))
-          (cookie (when (string= "xoxc" (substring token 0 4))
+          (cookie (when (slack-need-cookie-p token)
                     (read-from-minibuffer "Cookie: "))))
      (list :name name :token token :cookie cookie)))
   (cl-labels ((has-token-p (plist)


### PR DESCRIPTION
`slack-url-copy-file` was not compatible with `xoxc` tokens which
requires cookie to be present with the request. So this MR simply
fixes that.

I only tested these changes with an `xoxc` token, so I'm not sure that
it works with other tokens that do not require the cookie but there
are no reasons for this to not work.
