### PR TITLE
Fix missing lexbind declaration in slack-user-message.

### DIFF
--- a/slack-user-message.el
+++ b/slack-user-message.el
@@ -1,5 +1,26 @@
-;;; package --- Summary
+;;; slack-user-message.el ---                        -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2015  yuya.minami
+
+;; Author: yuya.minami <yuya.minami@yuyaminami-no-MacBook-Pro.local>
+;; Keywords: 
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
 ;;; Commentary:
+
+;; 
 
 ;;; Code:
 


### PR DESCRIPTION
Recent Emacs builds have changed how `cl-call-next-method` works in a way that [causes breakage when used with dynamic binding](https://lists.gnu.org/archive/html/bug-gnu-emacs/2022-07/msg01457.html) (but they work fine with lexical binding).  The slack-user-message.el file appears to have a missing / broken / incomplete header, which causes it to default to dynamic binding, which causes `cl-call-next-method` inside `slack-message-body' to fail.

This commit adds the file header and declares that slack-user-message should use lexical binding.

fixes yuya373/emacs-slack#570