### PR TITLE
Change endpoint used to retrieve more history

### DIFF
--- a/slack-message-buffer.el
+++ b/slack-message-buffer.el
@@ -304,9 +304,9 @@
                         (oset this cursor next-cursor)
                         (slack-room-set-messages room messages team)
                         (update-buffer (slack-room-sorted-messages room))))
-      (slack-conversations-view room team
-                                :cursor (oref this cursor)
-                                :after-success #'after-success))))
+      (slack-conversations-history room team
+                                   :cursor (oref this cursor)
+                                   :after-success #'after-success))))
 
 (cl-defmethod slack-buffer-display-pins-list ((this slack-message-buffer))
   (let ((team (slack-buffer-team this))


### PR DESCRIPTION
According to the changes in slack API, history now should be retrieved from `conversations.history`, not `conversations.view`  Fixes #577 