### PR TITLE
Add cookie to websocket requests

### DIFF
--- a/slack-websocket.el
+++ b/slack-websocket.el
@@ -102,7 +102,8 @@
                                 :on-open #'handle-on-open
                                 :on-close #'on-close
                                 :on-error #'on-error
-                                :nowait websocket-nowait-p)
+                                :nowait websocket-nowait-p
+                                :custom-header-alist (list (cons "Cookie" (format "d=%s" (slack-team-cookie team)))))
               (error
                (slack-log (format "An Error occured while opening websocket connection: %s"
                                   error-var)


### PR DESCRIPTION
According to @Nazar65's research, Slack now requires cookies to be added to websocket requests. Unlike the quickfix from #584, this MR sets the `Cookie' header directly to work correctly with multiple accounts.
Should fix issues #584, #585 