### PR TITLE
Fix wrong face attribute of box attribute.

### DIFF
--- a/slack-attachment.el
+++ b/slack-attachment.el
@@ -200,13 +200,13 @@
 
 (defface slack-message-action-primary-face
   '((t (:box (:line-width 1 :style released-button)
-             :foreground "#2aa198")))
+             :color "#2aa198")))
   "Face used to primary action."
   :group 'slack)
 
 (defface slack-message-action-danger-face
   '((t (:box (:line-width 1 :style released-button)
-             :foreground "#FF6E64")))
+             :color "#FF6E64")))
   "Face used to danger action."
   :group 'slack)
 

--- a/slack-block.el
+++ b/slack-block.el
@@ -772,7 +772,7 @@
                             map)))))
 
 (defface slack-button-block-element-face
-  '((t (:box (:line-width 1 :style released-button :foreground "#2aa198"))))
+  '((t (:box (:line-width 1 :style released-button :color "#2aa198"))))
   "Used to button block element"
   :group 'slack)
 
@@ -811,7 +811,7 @@
       (slack-block-select-from-option-group group)))
 
 (defface slack-select-block-element-face
-  '((t (:box (:line-width 1 :style released-button :forground "#2aa198"))))
+  '((t (:box (:line-width 1 :style released-button :color "#2aa198"))))
   "Used to select block element"
   :group 'slack)
 
@@ -1090,7 +1090,7 @@
                            (plist-get payload :confirm))))
 
 (defface slack-overflow-block-element-face
-  '((t (:box (:line-width 1 :style released-button :forground "#2aa198"))))
+  '((t (:box (:line-width 1 :style released-button :color "#2aa198"))))
   "Used to overflow block element"
   :group 'slack)
 
@@ -1153,7 +1153,7 @@
                             map)))))
 
 (defface slack-date-picker-block-element-face
-  '((t (:box (:line-width 1 :style released-button :forground "#2aa198"))))
+  '((t (:box (:line-width 1 :style released-button :color "#2aa198"))))
   "Used to date picker block element"
   :group 'slack)
 

--- a/slack-dialog-buffer.el
+++ b/slack-dialog-buffer.el
@@ -85,7 +85,7 @@
 
 (defface slack-dialog-submit-button-face
   '((t (:box (:line-width 1 :style released-button)
-             :foreground "#2aa198")))
+             :color "#2aa198")))
   "Used to dialog's submit button"
   :group 'slack)
 


### PR DESCRIPTION
Hello,

I instalked recent commit and try M-x slack-start,
 I got bellow error.

set-face-attribute: Invalid face box: :line-width, 1, :style, released-button, :foreground, "#2aa198"

This error occured due to wrong attribute :foreground.
After correct specifying :color instead of :foreground,
 this error seems fixed.

Thanks.