### PR TITLE
Fix void variable e on download emoji

### DIFF
--- a/slack-emoji.el
+++ b/slack-emoji.el
@@ -118,12 +118,10 @@ This runs asynchronously, splitting the emojis in batches of `slack-emoji-job-ba
                                                          (list (cons "name" (substring (symbol-name name) 1))
                                                                (cons "image" path)
                                                                (cons "style" "github")))))
-                                       (if (file-exists-p path)
-                                           (funcall ',(lambda (emoji) (push-new-emoji emoji)) emoji)
-                                         (slack-url-copy-file
-                                          url
-                                          path
-                                          ,team))
+                                       (if (not (file-exists-p path))
+                                           (slack-url-copy-file url path ,team))
+                                       
+                                       (funcall ',(lambda (emoji) (push-new-emoji emoji)) emoji)
                                        (add-to-list 'slack-emoji-paths path)))))
                     it)
                    (append

--- a/slack-emoji.el
+++ b/slack-emoji.el
@@ -124,9 +124,9 @@ This runs asynchronously, splitting the emojis in batches of `slack-emoji-job-ba
                                           url
                                           path
                                           ,team
-                                          :success (let ((e emoji))
-                                                     (lambda ()
-                                                       (funcall ',(lambda (emoji) (push-new-emoji emoji)) e))))
+                                          :success 
+                                          (lambda ()
+                                            (funcall ',(lambda (emoji) (push-new-emoji emoji)) emoji)))
                                          )
                                        (add-to-list 'slack-emoji-paths path)))))
                     it)

--- a/slack-emoji.el
+++ b/slack-emoji.el
@@ -123,11 +123,7 @@ This runs asynchronously, splitting the emojis in batches of `slack-emoji-job-ba
                                          (slack-url-copy-file
                                           url
                                           path
-                                          ,team
-                                          :success 
-                                          (lambda ()
-                                            (funcall ',(lambda (emoji) (push-new-emoji emoji)) emoji)))
-                                         )
+                                          ,team))
                                        (add-to-list 'slack-emoji-paths path)))))
                     it)
                    (append


### PR DESCRIPTION
I had an error and entire slack was blocked with error void varioable e

`Symbol’s value as variable is void: e
Mark set
#[nil ((funcall '#[(emoji) ((funcall --cl-push-new-emoji-- emoji)) ((--cl-push-new-emoji-- . #[(emoji) ((progn (puthash ... t ...) (setq emojify-user-emojis ...))) `

And its described in https://github.com/emacs-slack/emacs-slack/issues/599

After applying this patch everything is work as expected now.