### PR TITLE
Render messages with attachment blocks

### DIFF
--- a/slack-attachment.el
+++ b/slack-attachment.el
@@ -39,6 +39,7 @@
 
 (defclass slack-attachment ()
   ((fallback :initarg :fallback :initform nil)
+   (blocks :initarg :blocks :initform '())
    (title :initarg :title :initform nil)
    (title-link :initarg :title_link :initform nil)
    (pretext :initarg :pretext :initform nil)
@@ -167,6 +168,11 @@
         (plist-put payload :actions
                    (mapcar #'slack-attachment-action-create
                            (plist-get payload :actions))))
+
+  (setq payload
+        (plist-put payload :blocks
+                   (mapcar #'slack-create-layout-block
+                           (plist-get payload :blocks))))
 
   (when (numberp (plist-get payload :ts))
     (setq payload

--- a/slack-create-message.el
+++ b/slack-create-message.el
@@ -58,9 +58,9 @@
 
 (cl-defmethod slack-message-set-attachments ((m slack-message) payload)
   (let ((attachments (append (plist-get payload :attachments) nil)))
-    (if (< 0 (length attachments))
-        (oset m attachments
-              (mapcar #'slack-attachment-create attachments))))
+    (when (< 0 (length attachments))
+      (oset m attachments
+            (mapcar #'slack-attachment-create attachments))))
   m)
 
 (defun slack-message-set-blocks (message payload)


### PR DESCRIPTION
Some messages contain `attachments` with `blocks` field (instead of directly having `blocks` field), which are just regular Slack blocks. Here we check for them while rendering messages and if there is an attachment with blocks, we also render it.

Not quite sure if it's possible to have more than one attachment and they have blocks underneath them. I only saw one attachment with multiple blocks. If there is such thing, we can extend here in the future.

https://docs.slack.dev/legacy/legacy-messaging/legacy-secondary-message-attachments/#fields