### PR TITLE
Fix dark-gray color name issue

### DIFF
--- a/slack-mrkdwn.el
+++ b/slack-mrkdwn.el
@@ -93,7 +93,7 @@ Group 8 matches the closing parenthesis.")
 (defconst slack-mrkdwn-regex-list "^\\([[:blank:]]*\\)\\([0-9]+\\.\\|[-*]\\)\\([[:blank:]]\\)\\(.*\\)$")
 
 (defface slack-mrkdwn-list-face
-  '((t (:foreground "dark-gray" :weight bold)))
+  '((t (:foreground "#A9A9A9" :weight bold)))
   "Face used to mrkdwn list"
   :group 'slack)
 


### PR DESCRIPTION
## Summary
- Replace 'dark-gray' (hyphen) with '#A9A9A9' hex color
- 'dark-gray' with hyphen is not a standard X11 color name  
- X11 rgb.txt defines 'dark gray' (space) and 'DarkGray' → #A9A9A9
- Using hex color ensures compatibility across all Emacs configurations
- Prevents "Unable to load color \"dark-gray\"" errors

## Problem  
`slack-mrkdwn-list-face` used "dark-gray" with hyphen, but this is not a recognized X11 color name. In Emacs 31.0.50 development version, this causes "Unable to load color \"dark-gray\"" errors.

## Research Findings
- X11 rgb.txt contains "dark gray" and "DarkGray" → #A9A9A9
- "dark-gray" with hyphen is NOT a standard X11 color name
- In terminal/batch mode, only basic 8 colors are available
- In graphical Emacs, X11 colors should be available but may vary by configuration

## Solution
Changed from `(:foreground "dark-gray" :weight bold)` to `(:foreground "#A9A9A9" :weight bold)` using the exact hex color code for X11 "dark gray".

## Alternatives Considered
1. Use "dark gray" (space) - but terminal mode would still fail
2. Use fallback logic - but adds complexity  
3. Use hex color - most robust solution for all environments

Fixes color loading issue in Emacs 31.0.50+ where non-standard color names
cause errors.