### PR TITLE
Adopt users.prefs.get changes for parsing muted channels

### DIFF
--- a/slack-user.el
+++ b/slack-user.el
@@ -478,7 +478,7 @@ https://github.com/ErikKalkoken/slackApiDoc/blob/master/users.prefs.get.md"
                         (let* ((prefs (plist-get data :prefs))
                                (muted-channels
                                 (seq-map
-                                 #'car
+                                 (lambda (channel) (symbol-name (car channel)))
                                  (seq-filter
                                   (lambda (channel) (alist-get 'muted (cdr channel)))
                                   (alist-get 'channels (json-parse-string


### PR DESCRIPTION
Previously :muted_channels inside the preferences contained all muted channels in a string, separated by commas. Now, this information is kept under :all_notifications_prefs, in a JSON.